### PR TITLE
vcd-token: Add ContentType header to OAuth request

### DIFF
--- a/vcd-token.ps1
+++ b/vcd-token.ps1
@@ -11,7 +11,11 @@ try {
     $uri = "https://$($vcdhost)/oauth/tenant/$($org)/token" 
   }
   $body = "grant_type=refresh_token&refresh_token=$($token)"
-  $access_token = (Invoke-RestMethod -Method Post -Uri $uri -Headers @{'Accept' = 'application/json'} -Body $body -SkipCertificateCheck:$skipsslverify).access_token
+  $headers = @{
+    'Accept' = 'application/json'
+    'ContentType' = 'application/x-www-form-urlencoded'
+  }
+  $access_token = (Invoke-RestMethod -Method Post -Uri $uri -Headers $headers -Body $body -SkipCertificateCheck:$skipsslverify).access_token
   Write-Host -ForegroundColor Green ("Created access_token from token successfully")
 } catch {
   Write-Host -ForegroundColor Red ("Could not create access_token from token, response code: $($_.Exception.Response.StatusCode.value__)")


### PR DESCRIPTION
URL-encode the body using the `application/x-www-form-urlencoded` encoding algorithm as described in [rfc6749](https://datatracker.ietf.org/doc/html/rfc6749) and VMware's [Generate an API Access Token](https://docs.vmware.com/en/VMware-Cloud-Director/10.3/VMware-Cloud-Director-Tenant-Portal-Guide/GUID-A1B3B2FA-7B2C-4EE1-9D1B-188BE703EEDE.html) guide.

If I understand correctly by default [Invoke-RestMethod](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-restmethod?view=powershell-7.3#-body) uses `multipart/form-data`. I'm not sure about the implications, I thought it was fixing some problems I had. In the end I realized that I must have messed up something with the authentication parameters :sweat_smile:.

However, since I finished the PR already, I still think it follows the standard more closely and cleans up the passed headers a bit.